### PR TITLE
One possible solution to the hotmodule reloading bug. 

### DIFF
--- a/lib/webpack/rails/manifest.rb
+++ b/lib/webpack/rails/manifest.rb
@@ -18,6 +18,8 @@ module Webpack
         def asset_path source
           path = manifest["assetsByChunkName"][source]
           if path
+            # Only use main entry if full refresh, manifest has not been updated and contains an array.
+            path = path.first if path.is_a? Array
             "/#{::Rails::configuration.webpack.public_path}/#{path}"
           else
             raise "Can't find entry point '#{source}' in webpack manifest"


### PR DESCRIPTION
We were getting bugs where this was passing an unescaped array as a file path after refresh from hot reloader.

What is happening is that at certain points hot reload will ditch loading a patch and simply force refresh the page. When this happens the manifest is not updated. The `webpack-rails` helper gets the path from the manifest that was created by webpack under the `assetsByChunkName` key. Normally there is a single output file but in the case of an old manifest from hot reload there are multiple files provided in an array. This guards against the manifest key being an array. 

Example manifest entry: 

<img width="421" alt="screen shot 2015-07-17 at 4 29 06 pm" src="https://cloud.githubusercontent.com/assets/1256409/8750174/220bfa64-2ca6-11e5-94eb-939c80772463.png">

There may be a second side of this bug where could try to work out why hotloader is giving up in the first place but this seems to solve the problem.