### PR TITLE
add host configuration

### DIFF
--- a/lib/webpack/rails/helper.rb
+++ b/lib/webpack/rails/helper.rb
@@ -16,10 +16,12 @@ module Webpack
         return "" unless source.present?
 
         paths = Webpack::Rails::Manifest.asset_paths(source)
+        host = ::Rails.configuration.webpack.dev_server.host
+        port = ::Rails.configuration.webpack.dev_server.port
 
         if ::Rails.configuration.webpack.dev_server.enabled
           paths.map! do |p|
-            "http://localhost:#{::Rails.configuration.webpack.dev_server.port}#{p}"
+            "http://#{host}:#{port}#{p}"
           end
         end
 

--- a/lib/webpack/railtie.rb
+++ b/lib/webpack/railtie.rb
@@ -16,6 +16,7 @@ module Webpack
     config.webpack.binary = 'node_modules/.bin/webpack'
 
     config.webpack.dev_server = ActiveSupport::OrderedOptions.new
+    config.webpack.dev_server.host = 'localhost'
     config.webpack.dev_server.port = 3808
     config.webpack.dev_server.binary = 'node_modules/.bin/webpack-dev-server'
     config.webpack.dev_server.enabled = !::Rails.env.production?

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -15,7 +15,7 @@ describe 'webpack_asset_paths' do
     expect(webpack_asset_paths source).to eq(asset_paths)
   end
 
-  it "should have the user talk to the dev server if it's enabled for each path returned from the manifest" do
+  it "should have the user talk to the dev server if it's enabled for each path returned from the manifest defaulting to localhost" do
     ::Rails.configuration.webpack.dev_server.enabled = true
     ::Rails.configuration.webpack.dev_server.port = 4000
 
@@ -23,4 +23,16 @@ describe 'webpack_asset_paths' do
       "http://localhost:4000/a/a.js", "http://localhost:4000/b/b.js"
     ])
   end
+
+  it "should have the user talk to the specified dev server if it's enabled for each path returned from the manifest" do
+    ::Rails.configuration.webpack.dev_server.enabled = true
+    ::Rails.configuration.webpack.dev_server.port = 4000
+    ::Rails.configuration.webpack.dev_server.host = 'webpack.host'
+
+
+    expect(webpack_asset_paths source).to eq([
+      "http://webpack.host:4000/a/a.js", "http://webpack.host:4000/b/b.js"
+    ])
+  end
+
 end


### PR DESCRIPTION
Allow the host that we use for loading the web pack files to be configurable when we are using the dev server.

I needed this because i was doing some testing from MSIE in a Virtual Machine.

I needed to add `--host 0.0.0.0` to the web pack line on the Procfile to get web pack to bind, not sure if there's a way to put this in the `webpack.config.js` (i tried config.devServer.host but it didn't work) 