### PR TITLE
Gem must have lib with gem name

### DIFF
--- a/lib/webpack-rails.rb
+++ b/lib/webpack-rails.rb
@@ -1,0 +1,1 @@
+require 'webpack/rails'


### PR DESCRIPTION
The primary file in lib are named the same as gem. A developer can easily jump in and call require 'webpack-rails' with no problems.

That's why added the primary file in lib are named the same as gem. If some one uses this gem in engines and he is loading dependencies dynamically using gem name in that case its giving error.
like following
```
Gem.loaded_specs[engine_name].dependencies.each do |dependancy|
  require dependancy.name
end
```