### PR TITLE
Do not add source maps to the paths that are included as script tags

### DIFF
--- a/lib/tasks/webpack.rake
+++ b/lib/tasks/webpack.rake
@@ -13,6 +13,8 @@ namespace :webpack do
       raise "Can't find our webpack config file at #{config_file}"
     end
 
-    sh "#{webpack_bin} --bail --config #{config_file}"
+    result =  `#{webpack_bin} --bail --config #{config_file} 2>&1`
+    puts result
+    raise result unless $? == 0
   end
 end

--- a/lib/tasks/webpack.rake
+++ b/lib/tasks/webpack.rake
@@ -14,7 +14,6 @@ namespace :webpack do
     end
 
     result =  `#{webpack_bin} --bail --config #{config_file} 2>&1`
-    puts result
     raise result unless $? == 0
   end
 end

--- a/lib/webpack/rails/manifest.rb
+++ b/lib/webpack/rails/manifest.rb
@@ -21,8 +21,9 @@ module Webpack
         def asset_paths(source)
           paths = manifest["assetsByChunkName"][source]
           if paths
-            # Can be either a string or an array of strings
-            [paths].flatten.map do |p|
+            # Can be either a string or an array of strings.
+            # Do not include source maps as they are not javascript
+            [paths].flatten.reject { |p| p =~ /.*\.map$/ }.map do |p|
               "/#{::Rails.configuration.webpack.public_path}/#{p}"
             end
           else


### PR DESCRIPTION
Chrome was giving me an error: `Uncaught SyntaxError: Unexpected token :` in `application.js.map`. This appears to be because of this:

```
    <script src="http://localhost:3808/webpack/application.js"></script>
    <script src="http://localhost:3808/webpack/application.js.map"></script>
```

Where the second line is not supposed to be there as the sourcemap is not a javascript file. There is a comment at the end of application.js that tells the browser where to find the source map, so it doesn't need to be mentioned: 

    //# sourceMappingURL=application.js.map

Similar problem:
https://github.com/floridoo/gulp-sourcemaps/issues/170