### PR TITLE
Support https for dev server in development mode

### DIFF
--- a/lib/webpack/rails/helper.rb
+++ b/lib/webpack/rails/helper.rb
@@ -21,7 +21,7 @@ module Webpack
 
         if ::Rails.configuration.webpack.dev_server.enabled
           paths.map! do |p|
-            "http://#{host}:#{port}#{p}"
+            "//#{host}:#{port}#{p}"
           end
         end
 

--- a/lib/webpack/rails/manifest.rb
+++ b/lib/webpack/rails/manifest.rb
@@ -53,11 +53,12 @@ module Webpack
         end
 
         def load_dev_server_manifest
-          Net::HTTP.get(
+          http = Net::HTTP.new(
             "localhost",
-            dev_server_path,
-            ::Rails.configuration.webpack.dev_server.port
-          )
+            ::Rails.configuration.webpack.dev_server.port)
+          http.use_ssl = ::Rails.configuration.webpack.dev_server.https
+          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          http.get(dev_server_path).body
         rescue => e
           raise ManifestLoadError.new("Could not load manifest from webpack-dev-server at #{dev_server_url} - is it running, and is stats-webpack-plugin loaded?", e)
         end

--- a/lib/webpack/railtie.rb
+++ b/lib/webpack/railtie.rb
@@ -18,6 +18,7 @@ module Webpack
     config.webpack.dev_server = ActiveSupport::OrderedOptions.new
     config.webpack.dev_server.host = 'localhost'
     config.webpack.dev_server.port = 3808
+    config.webpack.dev_server.https = false
     config.webpack.dev_server.binary = 'node_modules/.bin/webpack-dev-server'
     config.webpack.dev_server.enabled = !::Rails.env.production?
 

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -20,7 +20,7 @@ describe 'webpack_asset_paths' do
     ::Rails.configuration.webpack.dev_server.port = 4000
 
     expect(webpack_asset_paths source).to eq([
-      "http://localhost:4000/a/a.js", "http://localhost:4000/b/b.js"
+      "//localhost:4000/a/a.js", "//localhost:4000/b/b.js"
     ])
   end
 
@@ -30,7 +30,7 @@ describe 'webpack_asset_paths' do
     ::Rails.configuration.webpack.dev_server.host = 'webpack.host'
 
     expect(webpack_asset_paths source).to eq([
-      "http://webpack.host:4000/a/a.js", "http://webpack.host:4000/b/b.js"
+      "//webpack.host:4000/a/a.js", "//webpack.host:4000/b/b.js"
     ])
   end
 end


### PR DESCRIPTION
We're using https in development mode for our rails app. So we need to run the webpack-dev-server with `https` flag on to prevent mixed content errors.

This PR adds an `https` option to `::Rails.configuration.webpack.dev_server` so the `load_dev_server_manifest` can load the manifest via https if enabled.
