### PR TITLE
Dynamic host for the webpack assets

### DIFF
--- a/lib/webpack/rails/helper.rb
+++ b/lib/webpack/rails/helper.rb
@@ -16,7 +16,7 @@ module Webpack
         return "" unless source.present?
 
         paths = Webpack::Rails::Manifest.asset_paths(source)
-        host = ::Rails.configuration.webpack.dev_server.host
+        host = request.host
         port = ::Rails.configuration.webpack.dev_server.port
 
         if ::Rails.configuration.webpack.dev_server.enabled

--- a/lib/webpack/rails/manifest.rb
+++ b/lib/webpack/rails/manifest.rb
@@ -34,8 +34,12 @@ module Webpack
         # Returns minified_file => map_file values as a hash
         def source_maps
           paths = manifest["assetsByChunkName"]
-          paths.each_with_object({}) do |(_name, files), obj|
-            obj[files[0]] = files[1]
+          if paths
+            paths.each_with_object({}) do |(_name, files), obj|
+              obj[files[0]] = files[1]
+            end
+          else
+            {}
           end
         end
 

--- a/lib/webpack/rails/manifest.rb
+++ b/lib/webpack/rails/manifest.rb
@@ -31,6 +31,14 @@ module Webpack
           end
         end
 
+        # Returns minified_file => map_file values as a hash
+        def source_maps
+          paths = manifest["assetsByChunkName"]
+          paths.each_with_object({}) do |(_name, files), obj|
+            obj[files[0]] = files[1]
+          end
+        end
+
         private
 
         def manifest


### PR DESCRIPTION
This allows testing on devices that are accessing the development server from somewhere other than localhost e.g. if you are loading the local site on your phone over the local wifi network using your local machine's ip address.