### PR TITLE
Separate client-side and server-side host and port

### DIFF
--- a/lib/webpack/rails/manifest.rb
+++ b/lib/webpack/rails/manifest.rb
@@ -54,7 +54,7 @@ module Webpack
 
         def load_dev_server_manifest
           http = Net::HTTP.new(
-            ::Rails.configuration.webpack.dev_server.host,
+            ::Rails.configuration.webpack.dev_server.private_host || ::Rails.configuration.webpack.dev_server.host,
             ::Rails.configuration.webpack.dev_server.port)
           http.use_ssl = ::Rails.configuration.webpack.dev_server.https
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/lib/webpack/rails/manifest.rb
+++ b/lib/webpack/rails/manifest.rb
@@ -54,7 +54,7 @@ module Webpack
 
         def load_dev_server_manifest
           http = Net::HTTP.new(
-            "localhost",
+            ::Rails.configuration.webpack.dev_server.host,
             ::Rails.configuration.webpack.dev_server.port)
           http.use_ssl = ::Rails.configuration.webpack.dev_server.https
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
@@ -81,7 +81,7 @@ module Webpack
         end
 
         def dev_server_url
-          "http://localhost:#{::Rails.configuration.webpack.dev_server.port}#{dev_server_path}"
+          "http://#{::Rails.configuration.webpack.dev_server.host}:#{::Rails.configuration.webpack.dev_server.port}#{dev_server_path}"
         end
       end
     end

--- a/lib/webpack/rails/manifest.rb
+++ b/lib/webpack/rails/manifest.rb
@@ -54,8 +54,8 @@ module Webpack
 
         def load_dev_server_manifest
           http = Net::HTTP.new(
-            ::Rails.configuration.webpack.dev_server.private_host || ::Rails.configuration.webpack.dev_server.host,
-            ::Rails.configuration.webpack.dev_server.port)
+            ::Rails.configuration.webpack.dev_server.server_host,
+            ::Rails.configuration.webpack.dev_server.server_port)
           http.use_ssl = ::Rails.configuration.webpack.dev_server.https
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
           http.get(dev_server_path).body

--- a/lib/webpack/railtie.rb
+++ b/lib/webpack/railtie.rb
@@ -17,8 +17,13 @@ module Webpack
 
     config.webpack.dev_server = ActiveSupport::OrderedOptions.new
     config.webpack.dev_server.host = 'localhost'
-    config.webpack.dev_server.private_host = 'localhost'
     config.webpack.dev_server.port = 3808
+    # The host and port to use when fetching the manifest
+    # This is helpful for e.g. docker containers, where the host and port you
+    # use via the web browser is not the same as those that the containers use
+    # to communicate among eachother
+    config.webpack.dev_server.server_host = 'localhost'
+    config.webpack.dev_server.server_port = 3808
     config.webpack.dev_server.https = false # note - this will use OpenSSL::SSL::VERIFY_NONE
     config.webpack.dev_server.binary = 'node_modules/.bin/webpack-dev-server'
     config.webpack.dev_server.enabled = !::Rails.env.production?

--- a/lib/webpack/railtie.rb
+++ b/lib/webpack/railtie.rb
@@ -17,6 +17,7 @@ module Webpack
 
     config.webpack.dev_server = ActiveSupport::OrderedOptions.new
     config.webpack.dev_server.host = 'localhost'
+    config.webpack.dev_server.private_host = 'localhost'
     config.webpack.dev_server.port = 3808
     config.webpack.dev_server.https = false # note - this will use OpenSSL::SSL::VERIFY_NONE
     config.webpack.dev_server.binary = 'node_modules/.bin/webpack-dev-server'

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -17,10 +17,11 @@ describe 'webpack_asset_paths' do
 
   it "should have the user talk to the dev server if it's enabled for each path returned from the manifest defaulting to localhost" do
     ::Rails.configuration.webpack.dev_server.enabled = true
+    ::Rails.configuration.webpack.dev_server.host = 'webpack.host'
     ::Rails.configuration.webpack.dev_server.port = 4000
 
     expect(webpack_asset_paths source).to eq([
-      "//localhost:4000/a/a.js", "//localhost:4000/b/b.js"
+      "//webpack.host:4000/a/a.js", "//webpack.host:4000/b/b.js"
     ])
   end
 

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -29,7 +29,10 @@ describe "Webpack::Rails::Manifest" do
 
   before do
     # Test that config variables work while we're here
+    ::Rails.configuration.webpack.dev_server.host = 'client-host'
     ::Rails.configuration.webpack.dev_server.port = 2000
+    ::Rails.configuration.webpack.dev_server.server_host = 'server-host'
+    ::Rails.configuration.webpack.dev_server.server_port = 4000
     ::Rails.configuration.webpack.manifest_filename = "my_manifest.json"
     ::Rails.configuration.webpack.public_path = "public_path"
     ::Rails.configuration.webpack.output_dir = "manifest_output"
@@ -39,7 +42,7 @@ describe "Webpack::Rails::Manifest" do
     before do
       ::Rails.configuration.webpack.dev_server.enabled = true
 
-      stub_request(:get, "http://localhost:2000/public_path/my_manifest.json").to_return(body: manifest, status: 200)
+      stub_request(:get, "http://server-host:4000/public_path/my_manifest.json").to_return(body: manifest, status: 200)
     end
 
     describe :asset_paths do
@@ -47,7 +50,7 @@ describe "Webpack::Rails::Manifest" do
 
       it "should error if we can't find the manifest" do
         ::Rails.configuration.webpack.manifest_filename = "broken.json"
-        stub_request(:get, "http://localhost:2000/public_path/broken.json").to_raise(SocketError)
+        stub_request(:get, "http://server-host:4000/public_path/broken.json").to_raise(SocketError)
 
         expect { Webpack::Rails::Manifest.asset_paths("entry1") }.to raise_error(Webpack::Rails::Manifest::ManifestLoadError)
       end


### PR DESCRIPTION
A follow-on to #17, this pull request introduces configuration values that allow for the client-side host and port to be different from the host and port that `manifest.rb` uses to fetch the manifest from the dev server. Why is this helpful? In a word: docker. Specifically, the host and port that the developer uses to bring up their rails app is not the same host and port that docker containers would use to communicate with each other. In fact, the external-facing hostname of the application usually isn't available to the containers when they are communicating among each other, on the internal network.