### PR TITLE
Dynamic host for the webpack assets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,3 @@ DEPENDENCIES
   rubocop
   webmock
   webpack-rails!
-
-BUNDLED WITH
-   1.10.6

--- a/lib/webpack/rails/helper.rb
+++ b/lib/webpack/rails/helper.rb
@@ -16,7 +16,7 @@ module Webpack
         return "" unless source.present?
 
         paths = Webpack::Rails::Manifest.asset_paths(source)
-        host = ::Rails.configuration.webpack.dev_server.host
+        host = request.host
         port = ::Rails.configuration.webpack.dev_server.port
 
         if ::Rails.configuration.webpack.dev_server.enabled

--- a/lib/webpack/rails/helper.rb
+++ b/lib/webpack/rails/helper.rb
@@ -13,10 +13,10 @@ module Webpack
       # Will raise an error if our manifest can't be found or the entry point does
       # not exist.
       def webpack_asset_paths(source)
-        return "" unless source.present?
+        return '' unless source.present?
 
         paths = Webpack::Rails::Manifest.asset_paths(source)
-        host = request.host
+        host = request.try(:host) || 'localhost'
         port = ::Rails.configuration.webpack.dev_server.port
 
         if ::Rails.configuration.webpack.dev_server.enabled


### PR DESCRIPTION
This allows testing on devices that are accessing the development server from somewhere other than localhost e.g. if you are loading the local site on your phone over the local wifi network using your local machine's ip address.

Recreating as I can't reopen the old PR