### PR TITLE
Allow host to be evaluated at request time

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ Have a look at the files in the `examples` directory. Of note:
   * Webpacked assets will be compiled to `public/webpack`
   * The manifest file is named `manifest.json`
 
+#### Dynamic host
+
+To have the host evaluated at request-time, set `host` to a proc:
+
+```ruby
+config.webpack.dev_server.host = proc { request.host }
+```
+
+This is useful when accessing your Rails app over the network (remember to bind both your Rails app and your WebPack server to `0.0.0.0`).
+
 ### Working with browser tests
 
 In development, we make sure that the `webpack-dev-server` is running when browser tests are running.
@@ -79,7 +89,7 @@ In development, we make sure that the `webpack-dev-server` is running when brows
 In CI, we manually run `webpack` to compile the assets to public and set `config.webpack.dev_server.enabled` to `false` in our `config/environments/test.rb`:
 
 ``` ruby
-  config.webpack.dev_server.enabled = !ENV['CI']
+config.webpack.dev_server.enabled = !ENV['CI']
 ```
 
 ### Production Deployment

--- a/lib/webpack/rails/helper.rb
+++ b/lib/webpack/rails/helper.rb
@@ -18,8 +18,10 @@ module Webpack
         paths = Webpack::Rails::Manifest.asset_paths(source)
         paths = paths.select {|p| p.ends_with? ".#{extension}" } if extension
 
-        host = ::Rails.configuration.webpack.dev_server.host
         port = ::Rails.configuration.webpack.dev_server.port
+
+        host = ::Rails.configuration.webpack.dev_server.host
+        host = instance_eval(&host) if host.respond_to?(:call)
 
         if ::Rails.configuration.webpack.dev_server.enabled
           paths.map! do |p|

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -40,4 +40,17 @@ describe 'webpack_asset_paths' do
       "//webpack.host:4000/a/a.js", "//webpack.host:4000/b/b.css"
     ])
   end
+
+  it "allows for the host to be evaluated at request time" do
+    # Simulate the helper context
+    request = double(:request, host: 'evaluated')
+
+    ::Rails.configuration.webpack.dev_server.enabled = true
+    ::Rails.configuration.webpack.dev_server.port = 4000
+    ::Rails.configuration.webpack.dev_server.host = proc { request.host }
+
+    expect(webpack_asset_paths source).to eq([
+      "//evaluated:4000/a/a.js", "//evaluated:4000/b/b.css"
+    ])
+  end
 end


### PR DESCRIPTION
Supports setting the `host` configuration option to a block which is evaluated in the view context. This allows the WebPack host to be dynamically determined at request-time, which is particularly useful if you're attempting to view the page over your local network (to test on mobile, for instance).

```ruby
config.webpack.dev_server.host = proc { request.host } # or -> (_) { request.host }
```

This PR just adds support for lazily-evaluating the host, but I'd like to propose this would make for a good, sensible default – the host of the WebPack server is rarely going to be different from the host of the Rails server.

–

**Edit:** I saw afterwards that this is similar to #25, but I think this approach is more flexible.