### PR TITLE
Fix CHILD_STATUS in rake task when English module is not required

### DIFF
--- a/lib/tasks/webpack.rake
+++ b/lib/tasks/webpack.rake
@@ -1,3 +1,5 @@
+require "English"
+
 namespace :webpack do
   desc "Compile webpack bundles"
   task compile: :environment do


### PR DESCRIPTION
This is a very simple fix: in most cases the `English` module is already required by Ruby, but I've ran into a case where the module is not required by Heroku's Ruby 2.3.1, thus making the rake task always fail (`CHILD_STATUS` always returned `nil`).

An alternative solution is to get rid of `require` and `CHILD_STATUS` and use `$?` instead.