### PR TITLE
Improve output result of webpack rake task

### DIFF
--- a/lib/tasks/webpack.rake
+++ b/lib/tasks/webpack.rake
@@ -18,6 +18,6 @@ namespace :webpack do
 
     result = `#{webpack_bin} --bail --config #{config_file} 2>&1`
     puts result
-    raise result unless $CHILD_STATUS == 0
+    raise result unless $CHILD_STATUS.exitstatus == 0
   end
 end

--- a/lib/tasks/webpack.rake
+++ b/lib/tasks/webpack.rake
@@ -17,6 +17,7 @@ namespace :webpack do
     end
 
     result = `#{webpack_bin} --bail --config #{config_file} 2>&1`
+    puts result
     raise result unless $CHILD_STATUS == 0
   end
 end


### PR DESCRIPTION
If there's an error in the compiled output of the webpack files, nothing is outputted to the console making it difficult to debug errors that occur. Even if there aren't errors, it would be good to see the output to ensure that the process is successful.

This was removed in https://github.com/mipearson/webpack-rails/commit/6b7a2b618e2b5f537fdf11348d78cba6fb3c28bb, but I believe it was done without awareness that it was how output was logged in command line.