### PR TITLE
Add HTTPS option specific for manifest load

### DIFF
--- a/lib/webpack/rails/manifest.rb
+++ b/lib/webpack/rails/manifest.rb
@@ -65,7 +65,7 @@ module Webpack
           host = ::Rails.configuration.webpack.dev_server.manifest_host
           port = ::Rails.configuration.webpack.dev_server.manifest_port
           http = Net::HTTP.new(host, port)
-          http.use_ssl = ::Rails.configuration.webpack.dev_server.https
+          http.use_ssl = ::Rails.configuration.webpack.dev_server.manifest_https
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
           http.get(dev_server_path).body
         rescue => e


### PR DESCRIPTION
Similar to the other manifest options (host + port), we should be able to specify the protocol for serving the manifest file. This is helpful for allowing the server be proxied via HTTPS but still run the dev server via HTTP.