### PR TITLE
Only error if manifest error was a module build failure

### DIFF
--- a/lib/webpack/rails/manifest.rb
+++ b/lib/webpack/rails/manifest.rb
@@ -26,7 +26,7 @@ module Webpack
       class << self
         # :nodoc:
         def asset_paths(source)
-          raise WebpackError, manifest["errors"] if manifest["errors"].present?
+          raise WebpackError, manifest["errors"] unless manifest_bundled?
 
           paths = manifest["assetsByChunkName"][source]
           if paths
@@ -41,6 +41,10 @@ module Webpack
         end
 
         private
+
+        def manifest_bundled?
+          !manifest["errors"].any? { |error| error.include? "Module build failed" }
+        end
 
         def manifest
           if ::Rails.configuration.webpack.dev_server.enabled


### PR DESCRIPTION
This allows webpack-rails to be used with non-breaking errors in the webpack manifest (such as linting).

Context: In our app, we use webpack-rails to serve assets to our Jasmine server when running tests. We want to be able to test and develop locally, even if there are webpack errors (like linting), as long as they don't break the webpack build. Webpack's errors are currently given in the manifest as a simple array of strings without any information about the loader that threw the error, so this PR only throws if it sees 'Module build failed' in the string.

Please let me know if you have any questions! 

//cc @juanca