### PR TITLE
Relax assumptions in webpack:compile rake tasks

### DIFF
--- a/lib/tasks/webpack.rake
+++ b/lib/tasks/webpack.rake
@@ -3,15 +3,21 @@ namespace :webpack do
   task compile: :environment do
     ENV["TARGET"] = 'production' # TODO: Deprecated, use NODE_ENV instead
     ENV["NODE_ENV"] = 'production'
-    webpack_bin = ::Rails.root.join(::Rails.configuration.webpack.binary)
+    webpack_bin = ::Rails.configuration.webpack.binary
     config_file = ::Rails.root.join(::Rails.configuration.webpack.config_file)
 
-    unless File.exist?(webpack_bin)
-      raise "Can't find our webpack executable at #{webpack_bin} - have you run `npm install`?"
+    which_webpack_result = `which #{webpack_bin}`.chomp
+    which_webpack_status = $CHILD_STATUS
+    unless which_webpack_status.success? && which_webpack_result != ""
+      warn <<-EOF.strip_heredoc
+      Running `which #{webpack_bin}` returned status code #{which_webpack_status.to_i} with output:
+      #{which_webpack_status}
+      EOF
+      raise "Can't find webpack executable at #{webpack_bin.inspect}. Have you run `npm install`?"
     end
 
     unless File.exist?(config_file)
-      raise "Can't find our webpack config file at #{config_file}"
+      raise "Can't find webpack config file at #{config_file}"
     end
 
     sh "#{webpack_bin} --config #{config_file} --bail"


### PR DESCRIPTION
* Don't assume that ::Rails.configuration.webpack.binary specifies a webpack path relative to Rails root.
* Don't assume that we know the exact webpack binary location (allow webpack executable to be on $PATH, in which case we no longer die with a File.exist? error).