### PR TITLE
Change dependency to railties

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     webpack-rails (0.9.9)
-      rails (>= 3.2.0)
+      railties (>= 3.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -140,6 +140,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  rails (>= 3.2.0)
   rake
   rspec
   rubocop

--- a/webpack-rails.gemspec
+++ b/webpack-rails.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "railties", ">= 3.2.0"
+  s.add_development_dependency "rails", ">= 3.2.0"
   s.required_ruby_version = '>= 2.0.0'
 end

--- a/webpack-rails.gemspec
+++ b/webpack-rails.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,example}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 3.2.0"
+  s.add_dependency "railties", ">= 3.2.0"
   s.required_ruby_version = '>= 2.0.0'
 end


### PR DESCRIPTION
I'm not sure if there are cases I'm not thinking of that this would break, but this gem seems to only actually depend on Railties, not Rails itself. This change would allow people with apps that are using the Railties + libs approach to using Rails to avoid having to include gems they don't need (ActionCable + ActionMailer in my case).