### PR TITLE
Only enable dev server in development & test

### DIFF
--- a/lib/webpack/railtie.rb
+++ b/lib/webpack/railtie.rb
@@ -32,7 +32,7 @@ module Webpack
 
     config.webpack.dev_server.https = false # note - this will use OpenSSL::SSL::VERIFY_NONE
     config.webpack.dev_server.binary = 'node_modules/.bin/webpack-dev-server'
-    config.webpack.dev_server.enabled = !::Rails.env.production?
+    config.webpack.dev_server.enabled = ::Rails.env.development? || ::Rails.env.test?
 
     config.webpack.output_dir = "public/webpack"
     config.webpack.public_path = "webpack"

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -85,7 +85,6 @@ describe "Webpack::Rails::Manifest" do
         end
       end
     end
-
   end
 
   context "with dev server disabled" do


### PR DESCRIPTION
Prior to this change, webpack-dev-server would also be enabled in
environments like staging, which is not something one would expect.

This seems like a more sensible default.