### PR TITLE
Use existing NODE_ENV if available

### DIFF
--- a/lib/tasks/webpack.rake
+++ b/lib/tasks/webpack.rake
@@ -2,7 +2,7 @@ namespace :webpack do
   desc "Compile webpack bundles"
   task compile: :environment do
     ENV["TARGET"] = 'production' # TODO: Deprecated, use NODE_ENV instead
-    ENV["NODE_ENV"] = 'production'
+    ENV["NODE_ENV"] ||= 'production'
     webpack_bin = ::Rails.root.join(::Rails.configuration.webpack.binary)
     config_file = ::Rails.root.join(::Rails.configuration.webpack.config_file)
 


### PR DESCRIPTION
Allows webpack config to respond to e.g., test environments