### PR TITLE
Support Webpack 2

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "license": "MIT",
   "dependencies": {
-    "stats-webpack-plugin": "^0.4.3",
-    "webpack": "^1.14.0",
-    "webpack-dev-server": "^1.16.2"
+    "stats-webpack-plugin": "*",
+    "webpack": "2.2.1",
+    "webpack-dev-server": "2.2.1"
   }
 }

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -29,7 +29,10 @@ var config = {
   },
 
   resolve: {
-    root: path.join(__dirname, '..', 'webpack')
+    modules: [
+      path.join(__dirname, '..', 'webpack'),
+      "node_modules"
+    ]
   },
 
   plugins: [
@@ -47,15 +50,11 @@ var config = {
 if (production) {
   config.plugins.push(
     new webpack.NoErrorsPlugin(),
-    new webpack.optimize.UglifyJsPlugin({
-      compressor: { warnings: false },
-      sourceMap: false
-    }),
+    new webpack.optimize.UglifyJsPlugin(),
     new webpack.DefinePlugin({
       'process.env': { NODE_ENV: JSON.stringify('production') }
     }),
-    new webpack.optimize.DedupePlugin(),
-    new webpack.optimize.OccurenceOrderPlugin()
+    new webpack.optimize.DedupePlugin()
   );
 } else {
   config.devServer = {


### PR DESCRIPTION
These are (obviously) breaking, but fairly minimal.

I applied these changes to my own app based on [the migrating guide](https://webpack.js.org/guides/migrating/) and what this gem puts into the initial config is fairly minimal, so the changes are not that great.

I think the best thing to do right now with this PR is to have others try it.  It's obviously not releasable in its current state because of the RC dependency.

Another question is: when Webpack 2 *is* released, should this gem support both versions?  If so, I'm guessing we'll need to have a bit more code to allow the user to choose which version.

Fixes #73 