### PR TITLE
Escape wrong chars before using

### DIFF
--- a/lib/tasks/webpack.rake
+++ b/lib/tasks/webpack.rake
@@ -14,6 +14,8 @@ namespace :webpack do
       raise "Can't find our webpack config file at #{config_file}"
     end
 
+    webpack_bin = Shellwords.escape(webpack_bin)
+    config_file = Shellwords.escape(config_file)
     sh "#{webpack_bin} --config #{config_file} --bail"
   end
 end


### PR DESCRIPTION
solves error raising 'sh syntax error ( unexpected' or similar. Path may contain any chars like space, brackets, slashes and etc.